### PR TITLE
Improve Python regexp and docstring highlighting

### DIFF
--- a/tests/python.python
+++ b/tests/python.python
@@ -28,6 +28,19 @@ import re
 import sys
 import time
 
+# The following regex is here to test syntax highlighting
+unused = re.compile(            # type: ignore
+    r"""\A
+        word
+        (?:                     # a comment
+           (?P<fill>.)?
+           (?P<align>[<>=^])    (?# another comment)
+        )?
+        another word\.\.\.
+        (?:\.(?P<precision>0|(?!0)\d+))?
+    \Z""",
+    re.VERBOSE | re.DOTALL)
+
 class RegExpResult(object):
     """RegExpResult holds the results for a regular expression."""
     def __init__(self):

--- a/themes/plastic-theme.json
+++ b/themes/plastic-theme.json
@@ -124,6 +124,10 @@
         "keyword.interface",
         "keyword.function",
         "markup.inline.raw",
+        "punctuation.parenthesis.named.begin.regexp",
+        "punctuation.parenthesis.named.end.regexp",
+        "punctuation.parenthesis.non-capturing.begin.regexp",
+        "punctuation.parenthesis.non-capturing.end.regexp",
         "storage.type",
         "support.constant",
         "support.type",
@@ -155,6 +159,15 @@
       }
     },
     {
+      "name": "Raven",
+      "scope": [
+        "string.quoted.docstring"
+      ],
+      "settings": {
+        "foreground": "#737c8c"
+      }
+    },
+    {
       "name": "Whiskey",
       "scope": [
         "entity.name.class",
@@ -164,7 +177,8 @@
         "entity.other.inherited-class",
         "markup.heading.setext",
         "meta.function-call.generic",
-        "support.function"
+        "support.function",
+        "support.other.escape.special.regexp"
       ],
       "settings": {
         "foreground": "#d19a66"


### PR DESCRIPTION
This addresses issue #6 as reported by @leiserfg.

The following changes have been made to improve Python syntax highlighting:

  - Capturing and non-capturing regexp parens are distinguished
    from regular text elements within the regexp. (Cornflower Blue)

  - Escaped elements, such as \d and \s, are distinguished from
    regular text elements within the regexp.  (Whiskey)

  - Docstrings are now different color from regular strings. They
    are a darker color to de-emphasize their importance with the
    surrounding code in a similar manner as comments, although
    not a faint as a comment. (Raven)

Also updated the sample Python test code with a complex regexp so we can
test the impact in future changes to the theme.